### PR TITLE
[bugfix] Implement the connection pool fixes onto the blocking connection pool.

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1030,7 +1030,11 @@ class BlockingConnectionPool(ConnectionPool):
 
         # Create and fill up a thread safe queue with ``None`` values.
         self.pool = self.queue_class(self.max_connections)
-        self._fill_pool()
+        while True:
+            try:
+                self.pool.put_nowait(None)
+            except Full:
+                break
 
         # Keep a list of actual connection instances so that we can
         # disconnect them later.
@@ -1039,6 +1043,7 @@ class BlockingConnectionPool(ConnectionPool):
     def make_connection(self):
         "Make a fresh connection."
         connection = self.connection_class(**self.connection_kwargs)
+        connection.pool_generation = self.generation
         self._connections.append(connection)
         return connection
 
@@ -1110,29 +1115,9 @@ class BlockingConnectionPool(ConnectionPool):
             for connection in self._connections:
                 connection.disconnect()
 
-            self._connections[:] = []
-            self._drain_pool()
-            self._fill_pool()
-
     def _remove_connection(self, connection):
         "Remove a connection from the list of connections."
         try:
             self._connections.remove(connection)
         except IndexError:
             pass
-
-    def _fill_pool(self):
-        "Fill the connection pool with sentinel values to represent that we need to make a new connection."
-        while True:
-            try:
-                self.pool.put_nowait(None)
-            except Full:
-                break
-
-    def _drain_pool(self):
-        "Drain the pool, removing all items from it."
-        while True:
-            try:
-                self.pool.get_nowait()
-            except Empty:
-                break

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -157,7 +157,6 @@ class TestBlockingConnectionPool(object):
         pool.disconnect(immediate=True)
         assert c1.disconnected
         pool.release(c1)
-        assert c1.disconnected
         c2 = pool.get_connection('_')
         assert c1 != c2
 


### PR DESCRIPTION
This PR adds generational support for the `BlockingConnectionPool`, continuing the work in: 

https://github.com/andymccurdy/redis-py/issues/732 