### PR TITLE
Locks should only enter if acquired

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -81,8 +81,9 @@ class Lock(object):
     def __enter__(self):
         # force blocking, as otherwise the user would have to check whether
         # the lock was actually acquired or not.
-        self.acquire(blocking=True)
-        return self
+        if self.acquire(blocking=True):
+            return self
+        raise LockError("Unable to acquire lock within the time specified")
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.release()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -59,6 +59,12 @@ class TestLock(object):
             assert sr.get('foo') == lock.local.token
         assert sr.get('foo') is None
 
+    def test_context_manager_raises_when_locked_not_acquired(self, r):
+        r.set('foo', 'bar')
+        with pytest.raises(LockError):
+            with self.get_lock(r, 'foo', blocking_timeout=0.1):
+                pass
+
     def test_high_sleep_raises_error(self, sr):
         "If sleep is higher than timeout, it should raise an error"
         with pytest.raises(LockError):


### PR DESCRIPTION
Backports a fix from upstream

https://github.com/andymccurdy/redis-py/commit/c99d2b98ff928a0709ee0453b60002e3e1254674