### PR TITLE
Achieve parity in do_acquire with upstream redis-py repo

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -118,12 +118,13 @@ class Lock(object):
                 return False
             mod_time.sleep(sleep)
 
-    def do_acquire(self, token):
-        if self.redis.setnx(self.name, token):
-            if self.timeout:
-                # convert to milliseconds
-                timeout = int(self.timeout * 1000)
-                self.redis.pexpire(self.name, timeout)
+    def do_acquire(self, token: str) -> bool:
+        if self.timeout:
+            # convert to milliseconds
+            timeout = int(self.timeout * 1000)
+        else:
+            timeout = None
+        if self.redis.set(self.name, token, nx=True, px=timeout):
             return True
         return False
 


### PR DESCRIPTION
Achieve parity with the current version of redis-py, which fixes a possible bug that results in locks being acquired without expirations being set
Discovered through the investigation of https://app.asana.com/0/1202371958531131/1203556149319920/f
Relevant: (https://github.com/redis/redis-py/issues/554)

Risk: Breaks Redis servers with version < 2.6.12

Code change itself seems relatively low risk, but I'm not sure about how to best test the changes thoroughly before merging

Might be unnecessary if @jdunck plans to do work on catching our redis-py fork up to the upstream repo