### PR TITLE
Backport improved readiness checks

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -13,20 +13,6 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
     # Adapted from https://bugs.python.org/review/23863/patch/14532/54418
     import socket
     import time
-    import errno
-
-    from select import select as _select
-
-    def select(rlist, wlist, xlist, timeout):
-        while True:
-            try:
-                return _select(rlist, wlist, xlist, timeout)
-            except InterruptedError as e:
-                # Python 2 does not define InterruptedError, instead
-                # try to catch an OSError with errno == EINTR == 4.
-                if getattr(e, 'errno', None) == getattr(errno, 'EINTR', 4):
-                    continue
-                raise
 
     # Wrapper for handling interruptable system calls.
     def _retryable_call(s, func, *args, **kwargs):
@@ -73,8 +59,6 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
         return _retryable_call(sock, sock.recv_into, *args, **kwargs)
 
 else:  # Python 3.5 and above automatically retry EINTR
-    from select import select
-
     def recv(sock, *args, **kwargs):
         return sock.recv(*args, **kwargs)
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -17,7 +17,7 @@ except ImportError:
 from redis._compat import (b, xrange, imap, byte_to_chr, unicode, bytes, long,
                            BytesIO, nativestr, basestring, iteritems,
                            LifoQueue, Empty, Full, urlparse, parse_qs,
-                           recv, recv_into, select, unquote)
+                           recv, recv_into, unquote)
 from redis.exceptions import (
     RedisError,
     ConnectionError,
@@ -30,6 +30,7 @@ from redis.exceptions import (
     ExecAbortError,
     ReadOnlyError
 )
+from redis.selector import DefaultSelector
 from redis.utils import HIREDIS_AVAILABLE
 if HIREDIS_AVAILABLE:
     import hiredis
@@ -499,6 +500,7 @@ class Connection(object):
             raise ConnectionError(self._error_message(e))
 
         self._sock = sock
+        self._selector = DefaultSelector(sock)
         try:
             self.on_connect()
         except RedisError:
@@ -632,8 +634,11 @@ class Connection(object):
         if not sock:
             self.connect()
             sock = self._sock
-        return self._parser.can_read() or \
-            bool(select([sock], [], [], timeout)[0])
+        return self._parser.can_read() or self._selector.can_read(timeout)
+
+    def is_ready_for_command(self):
+        "Check if the connection is ready for a command"
+        return self._selector.is_ready_for_command()
 
     def read_response(self):
         "Read the response from a previously sent command"
@@ -1001,6 +1006,23 @@ class ConnectionPool(object):
         except IndexError:
             connection = self.make_connection()
         self._in_use_connections.add(connection)
+        try:
+            # ensure this connection is connected to Redis
+            connection.connect()
+            # connections that the pool provides should be ready to send
+            # a command. if not, the connection was either returned to the
+            # pool before all data has been read or the socket has been
+            # closed. either way, reconnect and verify everything is good.
+            if not connection.is_ready_for_command():
+                connection.disconnect()
+                connection.connect()
+                if not connection.is_ready_for_command():
+                    raise ConnectionError('Connection not ready')
+        except:  # noqa: E722
+            # release the connection back to the pool so that we don't leak it
+            self.release(connection)
+            raise
+
         return connection
 
     def get_encoder(self):
@@ -1159,6 +1181,23 @@ class BlockingConnectionPool(ConnectionPool):
         # a new connection to add to the pool.
         if connection is None:
             connection = self.make_connection()
+
+        try:
+            # ensure this connection is connected to Redis
+            connection.connect()
+            # connections that the pool provides should be ready to send
+            # a command. if not, the connection was either returned to the
+            # pool before all data has been read or the socket has been
+            # closed. either way, reconnect and verify everything is good.
+            if not connection.is_ready_for_command():
+                connection.disconnect()
+                connection.connect()
+                if not connection.is_ready_for_command():
+                    raise ConnectionError('Connection not ready')
+        except:  # noqa: E722
+            # release the connection back to the pool so that we don't leak it
+            self.release(connection)
+            raise
 
         return connection
 

--- a/redis/selector.py
+++ b/redis/selector.py
@@ -1,0 +1,187 @@
+import errno
+import select
+from redis.exceptions import RedisError
+
+
+_DEFAULT_SELECTOR = None
+
+
+class BaseSelector(object):
+    """
+    Base class for all Selectors
+    """
+    def __init__(self, sock):
+        self.sock = sock
+
+    def can_read(self, timeout=0):
+        """
+        Return True if data is ready to be read from the socket,
+        otherwise False.
+
+        This doesn't guarentee that the socket is still connected, just that
+        there is data to read.
+
+        Automatically retries EINTR errors based on PEP 475.
+        """
+        while True:
+            try:
+                return self.check_can_read(timeout)
+            except (select.error, IOError) as ex:
+                if self.errno_from_exception(ex) == errno.EINTR:
+                    continue
+                return False
+
+    def is_ready_for_command(self, timeout=0):
+        """
+        Return True if the socket is ready to send a command,
+        otherwise False.
+
+        Automatically retries EINTR errors based on PEP 475.
+        """
+        while True:
+            try:
+                return self.check_is_ready_for_command(timeout)
+            except (select.error, IOError) as ex:
+                if self.errno_from_exception(ex) == errno.EINTR:
+                    continue
+                return False
+
+    def check_can_read(self, timeout):
+        """
+        Perform the can_read check. Subclasses should implement this.
+        """
+        raise NotImplementedError
+
+    def check_is_ready_for_command(self, timeout):
+        """
+        Perform the is_ready_for_command check. Subclasses should
+        implement this.
+        """
+        raise NotImplementedError
+
+    def close(self):
+        """
+        Close the selector.
+        """
+        self.sock = None
+
+    def errno_from_exception(self, ex):
+        """
+        Get the error number from an exception
+        """
+        if hasattr(ex, 'errno'):
+            return ex.errno
+        elif ex.args:
+            return ex.args[0]
+        else:
+            return None
+
+
+if hasattr(select, 'select'):
+    class SelectSelector(BaseSelector):
+        """
+        A select-based selector that should work on most platforms.
+
+        This is the worst poll strategy and should only be used if no other
+        option is available.
+        """
+        def check_can_read(self, timeout):
+            """
+            Return True if data is ready to be read from the socket,
+            otherwise False.
+
+            This doesn't guarentee that the socket is still connected, just
+            that there is data to read.
+            """
+            return bool(select.select([self.sock], [], [], timeout)[0])
+
+        def check_is_ready_for_command(self, timeout):
+            """
+            Return True if the socket is ready to send a command,
+            otherwise False.
+            """
+            r, w, e = select.select([self.sock], [self.sock], [self.sock],
+                                    timeout)
+            return bool(w and not r and not e)
+
+
+if hasattr(select, 'poll'):
+    class PollSelector(BaseSelector):
+        """
+        A poll-based selector that should work on (almost?) all versions
+        of Unix
+        """
+        _EVENT_MASK = (select.POLLIN | select.POLLPRI | select.POLLOUT |
+                       select.POLLERR | select.POLLHUP)
+        _READ_MASK = select.POLLIN | select.POLLPRI
+        _WRITE_MASK = select.POLLOUT
+
+        def __init__(self, sock):
+            super().__init__(sock)
+            self.poller = select.poll()
+            self.poller.register(sock, self._EVENT_MASK)
+
+        def close(self):
+            """
+            Close the selector.
+            """
+            try:
+                self.poller.unregister(self.sock)
+            except (KeyError, ValueError):
+                # KeyError is raised if somehow the socket was not registered
+                # ValueError is raised if the socket's file descriptor is
+                #   negative.
+                # In either case, we can't do anything better than to remove
+                # the reference to the poller.
+                pass
+            self.poller = None
+            self.sock = None
+
+        def check_can_read(self, timeout=0):
+            """
+            Return True if data is ready to be read from the socket,
+            otherwise False.
+
+            This doesn't guarentee that the socket is still connected, just
+            that there is data to read.
+            """
+            events = self.poller.poll(0)
+            return bool(events and events[0][1] & self._READ_MASK)
+
+        def check_is_ready_for_command(self, timeout=0):
+            """
+            Return True if the socket is ready to send a command,
+            otherwise False
+            """
+            events = self.poller.poll(0)
+            return bool(events and events[0][1] == self._WRITE_MASK)
+
+
+def has_selector(selector):
+    "Determine if the current platform has the selector available"
+    try:
+        if selector == 'poll':
+            # the select module offers the poll selector even if the platform
+            # doesn't support it. Attempt to poll for nothing to make sure
+            # poll is available
+            p = select.poll()
+            p.poll(0)
+        else:
+            # the other selectors will fail when instantiated
+            getattr(select, selector)().close()
+        return True
+    except (OSError, AttributeError):
+        return False
+
+
+def DefaultSelector(sock):
+    "Return the best selector for the platform"
+    global _DEFAULT_SELECTOR
+    if _DEFAULT_SELECTOR is None:
+        if has_selector('poll'):
+            _DEFAULT_SELECTOR = PollSelector
+        elif hasattr(select, 'select'):
+            _DEFAULT_SELECTOR = SelectSelector
+        else:
+            raise RedisError('Platform does not support any selectors')
+    return _DEFAULT_SELECTOR(sock)

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -6,6 +6,7 @@ import time
 import re
 
 from threading import Thread
+from redis.client import parse_client_list
 from redis.connection import ssl_available, to_bool
 from .conftest import skip_if_server_version_lt
 
@@ -21,10 +22,16 @@ class DummyConnection(object):
     def disconnect(self):
         self.disconnected = True
 
+    def connect(self):
+        pass
+
+    def is_ready_for_command(self):
+        return True
+
 
 class TestConnectionPool(object):
     def get_pool(self, connection_kwargs=None, max_connections=None,
-                 connection_class=DummyConnection):
+                 connection_class=redis.Connection):
         connection_kwargs = connection_kwargs or {}
         pool = redis.ConnectionPool(
             connection_class=connection_class,
@@ -34,7 +41,8 @@ class TestConnectionPool(object):
 
     def test_connection_creation(self):
         connection_kwargs = {'foo': 'bar', 'biz': 'baz'}
-        pool = self.get_pool(connection_kwargs=connection_kwargs)
+        pool = self.get_pool(connection_kwargs=connection_kwargs,
+                             connection_class=DummyConnection)
         connection = pool.get_connection('_')
         assert isinstance(connection, DummyConnection)
         assert connection.kwargs == connection_kwargs
@@ -72,6 +80,39 @@ class TestConnectionPool(object):
                              connection_class=redis.UnixDomainSocketConnection)
         expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,db=1>>'
         assert repr(pool) == expected
+
+    def test_pool_provides_healthy_connections(self):
+        pool = self.get_pool(connection_class=redis.Connection,
+                             max_connections=2)
+        conn1 = pool.get_connection('_')
+        conn2 = pool.get_connection('_')
+
+        # set a unique name on the connection we'll be testing
+        conn1._same_connection_value = 'killed-client'
+        conn1.send_command('client', 'setname', 'redis-py-1')
+        assert conn1.read_response() == b'OK'
+        pool.release(conn1)
+
+        # find the well named client in the client list
+        conn2.send_command('client', 'list')
+        client_list = parse_client_list(conn2.read_response())
+        for client in client_list:
+            if client['name'] == 'redis-py-1':
+                break
+        else:
+            assert False, 'Client redis-py-1 not found in client list'
+
+        # kill the well named client
+        conn2.send_command('client', 'kill', client['addr'])
+        assert conn2.read_response() == b'OK'
+
+        # our connection should have been disconnected, but a quality
+        # connection pool would know this and only provide a healthy
+        # connection.
+        conn = pool.get_connection('_')
+        assert conn == conn1
+        conn.send_command('ping')
+        assert conn.read_response() == b'PONG'
 
 
 class TestBlockingConnectionPool(object):
@@ -437,14 +478,20 @@ class TestSSLConnectionURLParsing(object):
     @pytest.mark.skipif(not ssl_available, reason="SSL not installed")
     def test_cert_reqs_options(self):
         import ssl
-        pool = redis.ConnectionPool.from_url('rediss://?ssl_cert_reqs=none')
+
+        class DummyConnectionPool(redis.ConnectionPool):
+            def get_connection(self, *args, **kwargs):
+                return self.make_connection()
+
+        pool = DummyConnectionPool.from_url(
+            'rediss://?ssl_cert_reqs=none')
         assert pool.get_connection('_').cert_reqs == ssl.CERT_NONE
 
-        pool = redis.ConnectionPool.from_url(
+        pool = DummyConnectionPool.from_url(
             'rediss://?ssl_cert_reqs=optional')
         assert pool.get_connection('_').cert_reqs == ssl.CERT_OPTIONAL
 
-        pool = redis.ConnectionPool.from_url(
+        pool = DummyConnectionPool.from_url(
             'rediss://?ssl_cert_reqs=required')
         assert pool.get_connection('_').cert_reqs == ssl.CERT_REQUIRED
 
@@ -532,3 +579,17 @@ class TestConnection(object):
             'UnixDomainSocketConnection',
             'path=/path/to/socket,db=0',
         )
+
+    def test_can_read(self, r):
+        connection = r.connection_pool.get_connection('ping')
+        assert not connection.can_read()
+        connection.send_command('ping')
+        # wait for the server to respond
+        wait_until = time.time() + 2
+        while time.time() < wait_until:
+            if connection.can_read():
+                break
+            time.sleep(0.01)
+        assert connection.can_read()
+        assert connection.read_response() == b'PONG'
+        assert not connection.can_read()


### PR DESCRIPTION
Revert our other patch and cherry-pick cfa2bc9b, which will use poll on supported systems to avoid the issues with select.